### PR TITLE
[auth-service] Improve database mocking strategy

### DIFF
--- a/backend/auth-service/__tests__/authRepository.test.js
+++ b/backend/auth-service/__tests__/authRepository.test.js
@@ -1,15 +1,21 @@
 import { describe, expect, jest, test } from "@jest/globals";
 import { hashPassword } from "../services/authService.js";
-// Mock di pg
+
+// mockquery simula la risposta della query nel db
 const mockQuery = jest.fn();
-jest.unstable_mockModule("pg", () => {
-  const mPool = {
-    query: mockQuery,
-    connect: jest.fn(),
-    end: jest.fn(),
-  };
-  return { Pool: jest.fn(() => mPool) };
-});
+
+// Create a mock pool object that mimics the pg Pool interface
+// This replaces the real database pool with test doubles
+// mockPool simula la pool e la connesione al database
+const mockPool = {
+  query: mockQuery,
+  connect: jest.fn(),
+  end: jest.fn(),
+};
+
+jest.unstable_mockModule("../config/database.js", () => ({
+  getPool: () => mockPool, // Replace real getPool with function that returns our mock
+}));
 
 // Importa il repository solo dopo aver configurato il mock
 const { findUser, testDatabaseConnection, executePrevQuery, createUser } =

--- a/backend/auth-service/config/database.js
+++ b/backend/auth-service/config/database.js
@@ -1,0 +1,26 @@
+import { Pool } from "pg";
+import dotenv from "dotenv";
+
+dotenv.config({ silent: true });
+// console.log(process.env);
+let pool;
+
+// Lazy initialization pattern - pool is created only on first getPool() call
+// Uses singleton pattern to ensure only one pool instance is shared across the application
+// Pool creation is centralized here following Single Responsibility Principle
+export function getPool() {
+  if (!pool) {
+    pool = new Pool({
+      host: process.env.POSTGRES_HOST_AUTH,
+      user: process.env.POSTGRES_USER_AUTH,
+      database: process.env.POSTGRES_DB_AUTH,
+      password: process.env.POSTGRES_PASSWORD_AUTH,
+      port: process.env.POSTGRES_PORT_AUTH,
+      max: 20,
+      idleTimeoutMillis: 30000,
+      connectionTimeoutMillis: 2000,
+      maxLifetimeSeconds: 60,
+    });
+  }
+  return pool;
+}

--- a/backend/auth-service/repositories/authRepository.js
+++ b/backend/auth-service/repositories/authRepository.js
@@ -1,28 +1,4 @@
-import { Pool } from "pg";
-import dotenv from "dotenv";
-
-dotenv.config({ silent: true });
-// console.log(process.env);
-let pool;
-
-// prima la pool veniva creata subito appena partiva l app, ora viene creata in modo ritardato(lazy) solo quando una funzione repository viene chiamata.
-// questo migliora il testing perche pool non e piu globale ma isolato in ogni funzione repository
-function getPool() {
-  if (!pool) {
-    pool = new Pool({
-      host: process.env.POSTGRES_HOST_AUTH,
-      user: process.env.POSTGRES_USER_AUTH,
-      database: process.env.POSTGRES_DB_AUTH,
-      password: process.env.POSTGRES_PASSWORD_AUTH,
-      port: process.env.POSTGRES_PORT_AUTH,
-      max: 20,
-      idleTimeoutMillis: 30000,
-      connectionTimeoutMillis: 2000,
-      maxLifetimeSeconds: 60,
-    });
-  }
-  return pool;
-}
+import { getPool } from "../config/database";
 
 export async function testDatabaseConnection() {
   const pool = getPool();


### PR DESCRIPTION
- Mock database.js module instead of pg for better testing
- Test repository functions without pg implementation details
- Match singleton pattern for database pool
- Ensure mocks are configured before module loading
- Add documentation about dynamic imports for testing

This change improves test isolation and follows better mocking practices by targeting our application boundary rather than external dependencies.