### PR TITLE
feat: uniform API path for orders and improve deploy reliability

### DIFF
--- a/ansible/roles/docker_app/tasks/main.yml
+++ b/ansible/roles/docker_app/tasks/main.yml
@@ -10,6 +10,7 @@
   community.docker.docker_compose_v2:
     project_src: "{{ app_dest_path }}"
     state: absent # Arresta e rimuove i container e le reti
+    remove_volumes: true #Aggiunto per evitare errori con le tabelle (all aggiunta di nuove colonne es quantity) che inizializzano i db con script init
   ignore_errors: yes # Ignora errori se i servizi non sono ancora attivi
   become: yes
   become_user: "{{ app_owner_user }}"

--- a/backend/orders-service/src/app.ts
+++ b/backend/orders-service/src/app.ts
@@ -22,6 +22,6 @@ server.addHook('preHandler', authMiddleware);
 
 server.register(healthRoutes, { prefix: '/health' }); // plugin isolato plugin = funzione che riceve l'istanza fastify e ci registra sopra rotte/hook/decoratori.
 
-server.register(orderRoutes, { prefix: '/orders'});
+server.register(orderRoutes, { prefix: '/api/orders'});
 
 export default server;

--- a/backend/products-service/init-scripts/products.sql
+++ b/backend/products-service/init-scripts/products.sql
@@ -11,14 +11,15 @@ CREATE TABLE products (
 
 
 -- Insert sample data into the products table
-INSERT INTO products (name, price, category, user_id) VALUES 
-('Mac m2', 999.99, 'Electronics', 1),
-('Desk Chair', 149.99, 'Furniture', 1),
-('Backpack', 39.99, 'Accessories', 1),
-('Pixel 10', 899.99, 'Electronics', 1),
-('Pixel 9', 599.99, 'Electronics', 2),
-('Coffee Table', 89.99, 'Furniture', 2),
-('Headphones', 49.99, 'Accessories', 2);
+INSERT INTO products (name, price, category, quantity, user_id) VALUES 
+('Mac m2', 999.99, 'Electronics', 5, 1),
+('Desk Chair', 149.99, 'Furniture', 2, 1),
+('Backpack', 39.99, 'Accessories', 3, 1),
+('Pixel 10', 899.99, 'Electronics', 5, 1),
+('Pixel 9', 599.99, 'Electronics', 10, 2),
+('Coffee Table', 89.99, 'Furniture', 5, 2),
+('Headphones', 49.99, 'Accessories', 6, 2),
+('Iphone 16', 899.99, 'Electronics', 10, 2);
 
 
 

--- a/frontend/src/components/CartPage.js
+++ b/frontend/src/components/CartPage.js
@@ -15,7 +15,7 @@ import { AuthContext } from "../context/AuthContext";
 import { useNavigate } from "react-router-dom";
 
 const isDev = process.env.REACT_APP_IS_DEV === "true";
-const ORDERS_URL = isDev ? "http://localhost:3040/orders" : "/api/orders";
+const ORDERS_URL = isDev ? "http://localhost:3040/api/orders" : "/api/orders";
 
 const CartPage = () => {
   const { cart, removeFromCart, updateQuantity, clearCart, getTotal } =


### PR DESCRIPTION
- Changed orders-service route prefix to /api/orders for consistency with products-service
- Updated Ansible deploy playbook to remove Docker volumes before (re)deploy
  - Ensures DB init scripts run and schema changes (e.g. new columns) are applied
  - Prevents errors due to missing columns when using Docker volumes